### PR TITLE
Fix #71

### DIFF
--- a/library/src/main/java/br/com/mauker/materialsearchview/MaterialSearchView.java
+++ b/library/src/main/java/br/com/mauker/materialsearchview/MaterialSearchView.java
@@ -91,6 +91,11 @@ public class MaterialSearchView extends FrameLayout {
      * Whether or not the MaterialSearchView will animate into view or just appear.
      */
     private boolean mShouldAnimate;
+    
+    /**
+     * Whether or not the MaterialSearchView will clonse under a click on the Tint View (Blank Area).
+     */
+    private boolean mShouldCloseOnTintClick;
 
     /**
      * Wheter to keep the search history or not.
@@ -252,7 +257,9 @@ public class MaterialSearchView extends FrameLayout {
         mTintView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                closeSearch();
+                if (mShouldCloseOnTintClick) {
+                    closeSearch();
+                }
             }
         });
 
@@ -647,18 +654,47 @@ public class MaterialSearchView extends FrameLayout {
         mSuggestionsListView.setOnItemClickListener(listener);
     }
 
+    /**
+     * Sets an OnItemLongClickListener to the suggestion list.
+     *
+     * @param listener - The ItemLongClickListener.
+     */
     public void setOnItemLongClickListener(AdapterView.OnItemLongClickListener listener) {
         mSuggestionsListView.setOnItemLongClickListener(listener);
     }
+    
+    /**
+     * Toggles the Tint click action.
+     *
+     * @param shouldClose - Whether the tint click should close the search view or not.
+     */
+    public void setCloseOnTintClick(boolean shouldClose) {
+        mShouldCloseOnTintClick = shouldClose;
+    }
 
+    /**
+     * Sets whether the MSV should be animated on open/close or not.
+     *
+     * @param mShouldAnimate - true if you want animations, false otherwise.
+     */
     public void setShouldAnimate(boolean mShouldAnimate) {
         this.mShouldAnimate = mShouldAnimate;
     }
 
+    /**
+     * Sets whether the MSV should be keeping track of the submited queries or not.
+     *
+     * @param keepHistory - true if you want to save the search history, false otherwise.
+     */
     public void setShouldKeepHistory(boolean keepHistory) {
         this.mShouldKeepHistory = keepHistory;
     }
 
+    /**
+     * Sets how many items you want to show from the history database.
+     *
+     * @param maxHistory - The number of items you want to display.
+     */
     public static void setMaxHistoryResults(int maxHistory) {
         MAX_HISTORY = maxHistory;
     }


### PR DESCRIPTION
Fix #71 
The fix was possible by adding the `setCloseOnTintClick` method, where you can disable the default close behavior when you click on the blank area (Tint).
Added more docs on the setters.