### PR TITLE
Added spanish translations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The MaterialSearchView supports the following languages:
 - Italian (Thanks to [Francesco Donzello](https://github.com/wideawake));
 - French (Thanks to [Robin](https://github.com/RobinPetit));
 - Bosnian, Croatian and Serbian (Thanks to [Luke](https://github.com/luq-0));
-- Spanish.
+- Spanish (Thanks to [Gloix](https://github.com/Gloix)).
 
 ## Sample GIF
 <img src='http://i.stack.imgur.com/C5LA4.gif' width='450' height='800' />

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ The MaterialSearchView supports the following languages:
 - Brazillian Portuguese (pt_BR);
 - Italian (Thanks to [Francesco Donzello](https://github.com/wideawake));
 - French (Thanks to [Robin](https://github.com/RobinPetit));
-- Bosnian, Croatian and Serbian (Thanks to [Luke](https://github.com/luq-0)).
+- Bosnian, Croatian and Serbian (Thanks to [Luke](https://github.com/luq-0));
+- Spanish.
 
 ## Sample GIF
 <img src='http://i.stack.imgur.com/C5LA4.gif' width='450' height='800' />

--- a/library/src/main/res/values-es/strings.xml
+++ b/library/src/main/res/values-es/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+    <string name="app_name" translatable="false">Material Search Library</string>
+    <string name="search_hint">Buscar&#8230;</string>
+    <string name="hint_prompt">Di un nombre o número</string>
+
+    <string name="cd_up_button">Navegar hacia arriba</string>
+    <string name="cd_voice_search">Búsqueda por voz</string>
+    <string name="cd_clear_button">Borrar</string>
+    <string name="cd_suggestion_icon">Ícono de elemento de lista</string>
+</resources>


### PR DESCRIPTION
I added translations for spanish. Please note that I did not use the word "button" (botón) in the `cd_up_button` string since ui control names should not be used in contentDescription tags. This should preferably be fixed for other languages.

Also, for the same string, I used the action form. This means that it would correspond to the translation of "Navigate up" instead of "Up navigation", since IMO buttons should try to mention actions. That's also according to iOS docs, but I didn't find anything related to android accessibility. If you feel that "Up navigation" is better, I can fix that.