### PR TITLE
fix nullable parameter for requestFocus()

### DIFF
--- a/library/src/main/java/br/com/mauker/materialsearchview/MaterialSearchView.kt
+++ b/library/src/main/java/br/com/mauker/materialsearchview/MaterialSearchView.kt
@@ -940,7 +940,7 @@ class MaterialSearchView @JvmOverloads constructor(
         mClearingFocus = false
     }
 
-    override fun requestFocus(direction: Int, previouslyFocusedRect: Rect): Boolean {
+    override fun requestFocus(direction: Int, previouslyFocusedRect: Rect?): Boolean {
         // Don't accept if we are clearing focus, or if the view isn't focusable.
         return !(mClearingFocus || !isFocusable) && mSearchEditText.requestFocus(direction, previouslyFocusedRect)
     }


### PR DESCRIPTION
fixes #171

The parameter `previouslyFocusedRect` must be nullable. This is currently not annotated in `ViewGroup.java` but it results in the crash of #171.